### PR TITLE
Extend 'kid' to also allow value type int

### DIFF
--- a/draft-ietf-cose-rfc8152bis-struct.xml
+++ b/draft-ietf-cose-rfc8152bis-struct.xml
@@ -571,7 +571,7 @@ empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
             <tr>
               <td>kid</td>
               <td>4</td>
-              <td>bstr</td>
+              <td>bstr / int</td>
               <td/>
               <td>Key identifier</td>
             </tr>
@@ -1204,7 +1204,7 @@ MAC_structure = [
       <sourcecode type="CDDL"><![CDATA[
 COSE_Key = {
     1 => tstr / int,          ; kty
-    ? 2 => bstr,              ; kid
+    ? 2 => bstr / int,        ; kid
     ? 3 => tstr / int,        ; alg
     ? 4 => [+ (tstr / int) ], ; key_ops
     ? 5 => bstr,              ; Base IV
@@ -1238,7 +1238,7 @@ COSE_KeySet = [+COSE_Key]
             <tr>
               <td>kid</td>
               <td>2</td>
-              <td>bstr</td>
+              <td>bstr / int</td>
               <td/>
               <td>Key identification value -- match to kid in message</td>
             </tr>

--- a/draft-ietf-cose-rfc8152bis-struct.xml
+++ b/draft-ietf-cose-rfc8152bis-struct.xml
@@ -597,7 +597,7 @@ Generic_Headers = (
     ? 1 => int / tstr,  ; algorithm identifier
     ? 2 => [+label],    ; criticality
     ? 3 => tstr / int,  ; content type
-    ? 4 => bstr,        ; key identifier
+    ? 4 => bstr / int,  ; key identifier
     ? 5 => bstr,        ; IV
     ? 6 => bstr         ; Partial IV
 )


### PR DESCRIPTION
As been discussed on the COSE mailing list (thread starting with [1]) it would be beneficial if 'kid' was extended to also have value type int. This PR shows the change integrated directly into the base draft. 


[1] https://mailarchive.ietf.org/arch/msg/cose/WUVutFNTVHd5m45xzS5mXPjwWsM/